### PR TITLE
Use single wrapping psr container

### DIFF
--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -11,8 +11,9 @@ declare(strict_types=1);
 namespace Laminas\Pimple\Config;
 
 use Pimple\Container;
+use Psr\Container\ContainerInterface;
 
 interface ConfigInterface
 {
-    public function configureContainer(Container $container) : void;
+    public function configureContainer(Container $container) : ContainerInterface;
 }

--- a/src/ContainerFactory.php
+++ b/src/ContainerFactory.php
@@ -12,14 +12,12 @@ namespace Laminas\Pimple\Config;
 
 use Pimple\Container;
 use Pimple\Psr11\Container as PsrContainer;
+use Psr\Container\ContainerInterface;
 
 class ContainerFactory
 {
-    public function __invoke(ConfigInterface $config) : PsrContainer
+    public function __invoke(ConfigInterface $config) : ContainerInterface
     {
-        $container = new Container();
-        $config->configureContainer($container);
-
-        return new PsrContainer($container);
+        return $config->configureContainer(new Container());
     }
 }

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -13,6 +13,7 @@ namespace LaminasTest\Pimple\Config;
 use Laminas\Pimple\Config\Config;
 use PHPUnit\Framework\TestCase;
 use Pimple\Container;
+use Pimple\Psr11\Container as Psr11Container;
 
 class ConfigTest extends TestCase
 {
@@ -22,6 +23,13 @@ class ConfigTest extends TestCase
     protected function setUp()
     {
         $this->container = new Container();
+    }
+
+    public function testConfigureContainerReturnsPsrContainer()
+    {
+        $container = (new Config([]))->configureContainer($this->container);
+
+        self::assertInstanceOf(Psr11Container::class, $container);
     }
 
     public function testInjectConfiguration()

--- a/test/ContainerFactoryTest.php
+++ b/test/ContainerFactoryTest.php
@@ -33,6 +33,9 @@ class ContainerFactoryTest extends TestCase
     {
         $factory = $this->factory;
         $config = $this->prophesize(ConfigInterface::class);
+        $config
+            ->configureContainer(Argument::type(Container::class))
+            ->willReturn($this->prophesize(ContainerInterface::class)->reveal());
 
         $container = $factory($config->reveal());
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no(*) But it affects the return type of Config::configureContainer()
| New Feature   | no
| RFC           | no
| QA            | no

### Description
Make injected factories, extension factories, delegator factories use the same psr container

ref: https://github.com/laminas/laminas-pimple-config/issues/2